### PR TITLE
Fix minor issues and jira tools release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-06-17
+### Changed
+- Refactored: Re-enabled previously disabled Jira tools in `registerJiraTools` and related server logic.
+- Fixed: Updated Confluence page URL construction to include `/wiki` prefix for correct page links.
+- Docs: Updated `README.md` for clarity, added explicit API token requirement, and improved setup instructions.
+- Chore: Bumped version to 0.1.3 in `package.json` and performed minor server code refactoring.
+
 ## [0.1.2] - 2025-06-16
 ### Added
 - Shebang added to `index.ts` for executable script support.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# Atlassian MCP Confluence Server
+# Atlassian MCP Server
 
-This project implements a Model Context Protocol (MCP) server for interacting with Atlassian Confluence and Jira via LLMs. It is designed for extensibility and supports multi-project Confluence access via request headers.
+This project implements a Model Context Protocol (MCP) server for interacting with Atlassian Confluence and Jira via LLMs.
 
 ## Features
 - Get, update, and explore Confluence pages, folders, children, and spaces
 - Perform advanced searches using CQL (Confluence Query Language)
-- ~~Interact with Jira issues (create, update, delete, search)~~
+- Interact with Jira issues (~~create, update, delete,~~ search)
 - Designed for LLM integration (e.g., Claude for Desktop)
-- Multi-project support via headers
 
 ## Local Setup
 
@@ -16,11 +15,12 @@ Follow these steps to set up the MCP server locally:
 ### Prerequisites
 - [Node.js](https://nodejs.org/) (v18 or later recommended)
 - [npm](https://www.npmjs.com/) (comes with Node.js)
+- API token for Atlassian. You can create on from [https://id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 
 ### Steps
 1. **Clone the repository:**
    ```sh
-   git clone <repo-url>
+   git clone https://github.com/Parthav46/atlassian-mcp.git
    cd atlassian-mcp
    ```
 2. **Install dependencies:**
@@ -29,9 +29,9 @@ Follow these steps to set up the MCP server locally:
    ```
 3. **Configure environment:**
    - You can set configuration options using command-line arguments or environment variables:
-     - `--base-url=<Confluence or Jira base URL>`
-     - `--token=<User token>`
-     - `--username=<Username>`
+     - `--base-url <Confluence or Jira base URL>`
+     - `--token <User token>`
+     - `--username <Username>`
    - These arguments override environment variables if both are set.
 4. **Build the project:**
    ```sh
@@ -39,7 +39,7 @@ Follow these steps to set up the MCP server locally:
    ```
 5. **Run the server using npx:**
    ```sh
-   npx atlassian-mcp --base-url=<Confluence or Jira base URL> --token=<User token> --username=<Username>
+   npx atlassian-mcp --base-url <Confluence or Jira base URL> --token <User token> --username <Username>
    ```
    - You can also use environment variables instead of command-line arguments.
 
@@ -61,14 +61,6 @@ Follow these steps to set up the MCP server locally:
      ```
    - Replace the placeholders with your actual configuration values.
    - This configuration works for both GitHub Copilot and Claude for Desktop.
-
-## Usage via npx (published package)
-
-Once the package is published to npm, you can run the server directly without cloning or building:
-
-```sh
-npx atlassian-mcp --base-url=<Confluence or Jira base URL> --token=<User token> --username=<Username>
-```
 
 ## Scripts
 - `npm run build` — Compile TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/src/index.js",
   "scripts": {
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,16 @@ dotenv.config();
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerTools } from "./registerTools.js";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, "..", "package.json"), "utf-8")
+);
 
 const server = new McpServer({
-  name: "confluence",
-  version: "1.0.0",
+  name: "atlassian",
+  version: pkg.version || "1.0.0",
   capabilities: {
     resources: {},
     tools: {},
@@ -20,7 +26,7 @@ registerTools(server);
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Confluence MCP Server running on stdio");
+  console.error("Atlassian MCP Server running on stdio");
 }
 
 main().catch((error) => {

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -2,6 +2,7 @@ import { registerJiraTools } from "./tools/jira/registerJiraTools";
 import { registerPageTools } from "./tools/confluence/registerPageTools";
 import { registerSpaceTools } from "./tools/confluence/registerSpaceTools";
 import { registerCqlTools } from "./tools/confluence/registerCqlTools";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 
 function getAtlassianConfig() {
   // Use --base-url, --token, --username for both
@@ -25,7 +26,7 @@ function getAtlassianConfig() {
   return Object.freeze({ baseUrl, token, username });
 }
 
-export function registerTools(server: any) {
+export function registerTools(server: McpServer) {
   const config = getAtlassianConfig();
   registerPageTools(server, config);
   registerSpaceTools(server, config);

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -1,4 +1,4 @@
-// import { registerJiraTools } from "./tools/jira/registerJiraTools";
+import { registerJiraTools } from "./tools/jira/registerJiraTools";
 import { registerPageTools } from "./tools/confluence/registerPageTools";
 import { registerSpaceTools } from "./tools/confluence/registerSpaceTools";
 import { registerCqlTools } from "./tools/confluence/registerCqlTools";
@@ -30,5 +30,5 @@ export function registerTools(server: any) {
   registerPageTools(server, config);
   registerSpaceTools(server, config);
   registerCqlTools(server, config);
-  // registerJiraTools(server, config);
+  registerJiraTools(server, config);
 }

--- a/src/tools/confluence/registerCqlTools.ts
+++ b/src/tools/confluence/registerCqlTools.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { ConfluenceClient } from "../../clients/confluenceClient";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 
-export function registerCqlTools(server: any, config: any) {
+export function registerCqlTools(server: McpServer, config: any) {
   server.tool(
     "confluence_search",
 

--- a/src/tools/confluence/registerPageTools.ts
+++ b/src/tools/confluence/registerPageTools.ts
@@ -83,7 +83,7 @@ export function registerPageTools(server: any, config: any) {
       }
 
       const page = response.data;
-      const pageUrl = page._links && page._links.webui ? `${config.baseUrl}${page._links.webui}` : 'No link available';
+      const pageUrl = page._links && page._links.webui ? `${config.baseUrl}/wiki${page._links.webui}` : 'No link available';
       return {
         content: [
           {

--- a/src/tools/confluence/registerPageTools.ts
+++ b/src/tools/confluence/registerPageTools.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { ConfluenceClient } from "../../clients/confluenceClient";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 
-export function registerPageTools(server: any, config: any) {
+export function registerPageTools(server: McpServer, config: any) {
   server.tool(
     "get-page",
     "Get a Confluence page by ID (optionally specify content format: storage or markdown)",

--- a/src/tools/confluence/registerSpaceTools.ts
+++ b/src/tools/confluence/registerSpaceTools.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { ConfluenceClient } from "../../clients/confluenceClient";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 
-export function registerSpaceTools(server: any, config: any) {
+export function registerSpaceTools(server: McpServer, config: any) {
   server.tool(
     "get-folder",
     "Get a Confluence folder by ID",

--- a/src/tools/jira/registerJiraTools.ts
+++ b/src/tools/jira/registerJiraTools.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { JiraClient } from "../../clients/jiraClient";
 import { parseJiraDescription, parseJiraSubtasks } from './jiraUtils';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 
-export function registerJiraTools(server: any, config: any) {
+export function registerJiraTools(server: McpServer, config: any) {
   server.tool(
     "search-jira-issues",
     "Search Jira issues using JQL",
@@ -114,9 +115,27 @@ export function registerJiraTools(server: any, config: any) {
   server.tool(
     "create-jira-issue",
     "(WIP) Create a new Jira issue. This tool is a work in progress and may not be fully functional yet.",
-    { issueData: z.any().describe("Jira issue data (JSON)") },
+    {
+      issueData: z.object({
+        fields: z.object({
+          project: z.object({
+            key: z.string().describe("Project key")
+          }),
+          summary: z.string().describe("Issue summary"),
+          issuetype: z.object({
+            id: z.string().optional().describe("Issue type ID"),
+            name: z.string().optional().describe("Issue type name")
+          }),
+          description: z.string().optional().describe("Issue description"),
+          assignee: z.object({
+            id: z.string().optional(),
+            name: z.string().optional()
+          }).optional(),
+        })
+      }).describe("Jira issue data (JSON)")
+    },
     async (
-      { issueData }: { issueData: any },
+      { issueData }: { issueData: { fields: any } },
       _extra: any
     ) => {
       const client = new JiraClient(config);
@@ -134,14 +153,17 @@ export function registerJiraTools(server: any, config: any) {
         ]
       };
     }
-  );
+  ).disable(); // Disable this tool for now as it is a work in progress
 
   server.tool(
     "update-jira-issue",
     "(WIP) Update a Jira issue by key. This tool is a work in progress and may not be fully functional yet.",
-    { issueKey: z.string().describe("Jira issue key"), issueData: z.any().describe("Jira issue update data (JSON)") },
+    { 
+      issueKey: z.string().describe("Jira issue key"), 
+      issueData: z.any().describe("Jira issue update data (JSON)") 
+    },
     async (
-      { issueKey, issueData }: { issueKey: string; issueData: any },
+      { issueKey, issueData }: { issueKey: string; issueData?: any },
       _extra: any
     ) => {
       const client = new JiraClient(config);
@@ -158,7 +180,7 @@ export function registerJiraTools(server: any, config: any) {
         ]
       };
     }
-  );
+  ).disable(); // Disable this tool for now as it is a work in progress
 
   server.tool(
     "delete-jira-issue",

--- a/src/tools/jira/registerJiraTools.ts
+++ b/src/tools/jira/registerJiraTools.ts
@@ -153,7 +153,7 @@ export function registerJiraTools(server: McpServer, config: any) {
         ]
       };
     }
-  ).disable(); // Disable this tool for now as it is a work in progress
+  );
 
   server.tool(
     "update-jira-issue",
@@ -180,7 +180,7 @@ export function registerJiraTools(server: McpServer, config: any) {
         ]
       };
     }
-  ).disable(); // Disable this tool for now as it is a work in progress
+  );
 
   server.tool(
     "delete-jira-issue",

--- a/src/tools/jira/registerJiraTools.ts
+++ b/src/tools/jira/registerJiraTools.ts
@@ -82,7 +82,7 @@ export function registerJiraTools(server: any, config: any) {
 
   server.tool(
     "get-jira-issue",
-    "Get a Jira issue by key",
+    "Get a Jira issue by key. Returns issue details including description and subtasks.",
     { issueKey: z.string().describe("Jira issue key") },
     async (
       { issueKey }: { issueKey: string },
@@ -113,7 +113,7 @@ export function registerJiraTools(server: any, config: any) {
 
   server.tool(
     "create-jira-issue",
-    "Create a new Jira issue",
+    "(WIP) Create a new Jira issue. This tool is a work in progress and may not be fully functional yet.",
     { issueData: z.any().describe("Jira issue data (JSON)") },
     async (
       { issueData }: { issueData: any },
@@ -138,7 +138,7 @@ export function registerJiraTools(server: any, config: any) {
 
   server.tool(
     "update-jira-issue",
-    "Update a Jira issue by key",
+    "(WIP) Update a Jira issue by key. This tool is a work in progress and may not be fully functional yet.",
     { issueKey: z.string().describe("Jira issue key"), issueData: z.any().describe("Jira issue update data (JSON)") },
     async (
       { issueKey, issueData }: { issueKey: string; issueData: any },

--- a/tests/tools/registerPageTools.test.ts
+++ b/tests/tools/registerPageTools.test.ts
@@ -185,7 +185,7 @@ describe('registerPageTools', () => {
       content: [
         {
           type: 'text',
-          text: 'Created page: New Page (https://example.atlassian.net/pages/new1)'
+          text: 'Created page: New Page (https://example.atlassian.net/wiki/pages/new1)'
         }
       ]
     });


### PR DESCRIPTION
## Changes:
- Refactored: Re-enabled previously disabled Jira tools in `registerJiraTools` and related server logic.
- Fixed: Updated Confluence page URL construction to include `/wiki` prefix for correct page links.
- Docs: Updated `README.md` for clarity, added explicit API token requirement, and improved setup instructions.
- Chore: Bumped version to 0.1.3 in `package.json` and performed minor server code refactoring.